### PR TITLE
Task/pta 5878

### DIFF
--- a/src/MySnsToPta/aws_syslog_mapper.py
+++ b/src/MySnsToPta/aws_syslog_mapper.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
 import json
-from typing import Any, Dict, Optional, Tuple
-
+from typing import Any, Dict, Optional, Tuple, Union
 
 def _g(obj: Dict[str, Any], path: str, *, default: Any = None) -> Any:
+    """Safe getter for dotted paths."""
     cur: Any = obj
     for part in path.split("."):
         if isinstance(cur, dict) and part in cur:
@@ -11,12 +12,11 @@ def _g(obj: Dict[str, Any], path: str, *, default: Any = None) -> Any:
             return default
     return cur
 
-
 def _pick_event_time(ev: Dict[str, Any]) -> Optional[str]:
     return _g(ev, "detail.eventTime") or ev.get("time")
 
-
 def _require_strings(payload: Dict[str, Any], paths: Tuple[str, ...]) -> Tuple[bool, str]:
+    """Validates that each dotted path exists and is a non-empty string."""
     missing = []
     wrong_type = []
     for p in paths:
@@ -36,8 +36,8 @@ def _require_strings(payload: Dict[str, Any], paths: Tuple[str, ...]) -> Tuple[b
         return False, "; ".join(parts)
     return True, ""
 
-
 def _detect_builder(ev: Dict[str, Any]) -> str:
+    """Returns 'access_key' or 'password'."""
     event_name = _g(ev, "detail.eventName")
     console_login = _g(ev, "detail.responseElements.ConsoleLogin")
     access_key_id = _g(ev, "detail.userIdentity.accessKeyId")
@@ -47,7 +47,6 @@ def _detect_builder(ev: Dict[str, Any]) -> str:
     if isinstance(access_key_id, str) and access_key_id.strip():
         return "access_key"
     raise ValueError("Unsupported event type for these builders")
-
 
 def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
     builder_type = _detect_builder(event)
@@ -104,8 +103,7 @@ def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
 
     return mapped
 
-
-def normalize_aws_syslog(syslog: str | Dict[str, Any]) -> Dict[str, Any]:
+def normalize_aws_syslog(syslog: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
     if isinstance(syslog, str):
         try:
             event = json.loads(syslog)

--- a/src/MySnsToPta/aws_syslog_mapper.py
+++ b/src/MySnsToPta/aws_syslog_mapper.py
@@ -1,0 +1,118 @@
+import json
+from typing import Any, Dict, Optional, Tuple
+
+
+def _g(obj: Dict[str, Any], path: str, *, default: Any = None) -> Any:
+    cur: Any = obj
+    for part in path.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return default
+    return cur
+
+
+def _pick_event_time(ev: Dict[str, Any]) -> Optional[str]:
+    return _g(ev, "detail.eventTime") or ev.get("time")
+
+
+def _require_strings(payload: Dict[str, Any], paths: Tuple[str, ...]) -> Tuple[bool, str]:
+    missing = []
+    wrong_type = []
+    for p in paths:
+        val = _g(payload, p)
+        if val is None or (isinstance(val, str) and val.strip() == ""):
+            missing.append(p)
+        elif not isinstance(val, str):
+            wrong_type.append((p, type(val).__name__))
+    if missing or wrong_type:
+        parts = []
+        if missing:
+            parts.append(f"missing: {', '.join(missing)}")
+        if wrong_type:
+            parts.append(
+                "wrong types: " + ", ".join(f"{p}={t}" for p, t in wrong_type)
+            )
+        return False, "; ".join(parts)
+    return True, ""
+
+
+def _detect_builder(ev: Dict[str, Any]) -> str:
+    event_name = _g(ev, "detail.eventName")
+    console_login = _g(ev, "detail.responseElements.ConsoleLogin")
+    access_key_id = _g(ev, "detail.userIdentity.accessKeyId")
+
+    if event_name == "ConsoleLogin" and isinstance(console_login, str):
+        return "password"
+    if isinstance(access_key_id, str) and access_key_id.strip():
+        return "access_key"
+    raise ValueError("Unsupported event type for these builders")
+
+
+def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
+    builder_type = _detect_builder(event)
+
+    event_time = _pick_event_time(event)
+    mapped: Dict[str, Any] = {
+        "eventTime": event_time,
+        "eventSource": _g(event, "detail.eventSource"),
+        "eventName": _g(event, "detail.eventName"),
+        "sourceIPAddress": _g(event, "detail.sourceIPAddress"),
+        "eventID": _g(event, "detail.eventID"),
+        "userIdentity": {
+            "accountId": _g(event, "detail.userIdentity.accountId"),
+            "userName": _g(event, "detail.userIdentity.userName"),
+            "accessKeyId": _g(event, "detail.userIdentity.accessKeyId"),
+        },
+        "responseElements": {
+            "ConsoleLogin": _g(event, "detail.responseElements.ConsoleLogin")
+        },
+    }
+
+    if builder_type == "access_key":
+        mapped.pop("responseElements", None)
+    else:
+        if "userIdentity" in mapped and isinstance(mapped["userIdentity"], dict):
+            mapped["userIdentity"].pop("accessKeyId", None)
+
+    if builder_type == "access_key":
+        ok, err = _require_strings(
+            mapped,
+            (
+                "eventTime",
+                "userIdentity.accountId",
+                "userIdentity.accessKeyId",
+                "userIdentity.userName",
+            ),
+        )
+    else:
+        ok, err = _require_strings(
+            mapped,
+            (
+                "eventTime",
+                "userIdentity.accountId",
+                "userIdentity.userName",
+                "eventName",
+                "responseElements.ConsoleLogin",
+            ),
+        )
+        if ok and mapped.get("eventName") != "ConsoleLogin":
+            ok, err = False, "eventName must be 'ConsoleLogin' for the password builder"
+
+    if not ok:
+        raise ValueError(f"Mandatory field validation failed: {err}")
+
+    return mapped
+
+
+def normalize_aws_syslog(syslog: str | Dict[str, Any]) -> Dict[str, Any]:
+    if isinstance(syslog, str):
+        try:
+            event = json.loads(syslog)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to parse JSON: {e}") from e
+    elif isinstance(syslog, dict):
+        event = syslog
+    else:
+        raise ValueError("syslog must be a JSON string or dict")
+    return map_event_to_java_source(event)

--- a/src/MySnsToPta/aws_syslog_mapper.py
+++ b/src/MySnsToPta/aws_syslog_mapper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import json
 from typing import Any, Dict, Optional, Tuple, Union
 
+# ---------- Flexible getters ----------
 def _g(obj: Dict[str, Any], path: str, *, default: Any = None) -> Any:
     """Safe getter for dotted paths."""
     cur: Any = obj
@@ -12,9 +13,39 @@ def _g(obj: Dict[str, Any], path: str, *, default: Any = None) -> Any:
             return default
     return cur
 
-def _pick_event_time(ev: Dict[str, Any]) -> Optional[str]:
-    return _g(ev, "detail.eventTime") or ev.get("time")
+def _get_event_name(ev):
+    return _g(ev, "detail.eventName") or ev.get("eventName")
 
+def _get_console_login(ev):
+    return _g(ev, "detail.responseElements.ConsoleLogin") or \
+           _g(ev, "responseElements.ConsoleLogin")
+
+def _get_access_key_id(ev):
+    return _g(ev, "detail.userIdentity.accessKeyId") or \
+           _g(ev, "userIdentity.accessKeyId")
+
+def _get_account_id(ev):
+    return _g(ev, "detail.userIdentity.accountId") or \
+           _g(ev, "userIdentity.accountId")
+
+def _get_user_name(ev):
+    return _g(ev, "detail.userIdentity.userName") or \
+           _g(ev, "userIdentity.userName")
+
+def _get_event_time(ev):
+    return _g(ev, "detail.eventTime") or ev.get("eventTime") or ev.get("time")
+
+def _get_event_source(ev):
+    return _g(ev, "detail.eventSource") or ev.get("eventSource")
+
+def _get_source_ip(ev):
+    return _g(ev, "detail.sourceIPAddress") or ev.get("sourceIPAddress")
+
+def _get_event_id(ev):
+    return _g(ev, "detail.eventID") or ev.get("eventID")
+
+
+# ---------- Validation ----------
 def _require_strings(payload: Dict[str, Any], paths: Tuple[str, ...]) -> Tuple[bool, str]:
     """Validates that each dotted path exists and is a non-empty string."""
     missing = []
@@ -30,17 +61,17 @@ def _require_strings(payload: Dict[str, Any], paths: Tuple[str, ...]) -> Tuple[b
         if missing:
             parts.append(f"missing: {', '.join(missing)}")
         if wrong_type:
-            parts.append(
-                "wrong types: " + ", ".join(f"{p}={t}" for p, t in wrong_type)
-            )
+            parts.append("wrong types: " + ", ".join(f"{p}={t}" for p, t in wrong_type))
         return False, "; ".join(parts)
     return True, ""
 
+
+# ---------- Builder detection ----------
 def _detect_builder(ev: Dict[str, Any]) -> str:
     """Returns 'access_key' or 'password'."""
-    event_name = _g(ev, "detail.eventName")
-    console_login = _g(ev, "detail.responseElements.ConsoleLogin")
-    access_key_id = _g(ev, "detail.userIdentity.accessKeyId")
+    event_name = _get_event_name(ev)
+    console_login = _get_console_login(ev)
+    access_key_id = _get_access_key_id(ev)
 
     if event_name == "ConsoleLogin" and isinstance(console_login, str):
         return "password"
@@ -48,23 +79,24 @@ def _detect_builder(ev: Dict[str, Any]) -> str:
         return "access_key"
     raise ValueError("Unsupported event type for these builders")
 
+
+# ---------- Main mapping ----------
 def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
     builder_type = _detect_builder(event)
 
-    event_time = _pick_event_time(event)
     mapped: Dict[str, Any] = {
-        "eventTime": event_time,
-        "eventSource": _g(event, "detail.eventSource"),
-        "eventName": _g(event, "detail.eventName"),
-        "sourceIPAddress": _g(event, "detail.sourceIPAddress"),
-        "eventID": _g(event, "detail.eventID"),
+        "eventTime": _get_event_time(event),
+        "eventSource": _get_event_source(event),
+        "eventName": _get_event_name(event),
+        "sourceIPAddress": _get_source_ip(event),
+        "eventID": _get_event_id(event),
         "userIdentity": {
-            "accountId": _g(event, "detail.userIdentity.accountId"),
-            "userName": _g(event, "detail.userIdentity.userName"),
-            "accessKeyId": _g(event, "detail.userIdentity.accessKeyId"),
+            "accountId": _get_account_id(event),
+            "userName": _get_user_name(event),
+            "accessKeyId": _get_access_key_id(event),
         },
         "responseElements": {
-            "ConsoleLogin": _g(event, "detail.responseElements.ConsoleLogin")
+            "ConsoleLogin": _get_console_login(event)
         },
     }
 
@@ -102,6 +134,7 @@ def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
         raise ValueError(f"Mandatory field validation failed: {err}")
 
     return mapped
+
 
 def normalize_aws_syslog(syslog: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
     if isinstance(syslog, str):

--- a/src/MySnsToPta/aws_syslog_mapper.py
+++ b/src/MySnsToPta/aws_syslog_mapper.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 import json
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
-# ---------- Flexible getters ----------
+# ---------- Flexible getter ----------
 def _g(obj: Dict[str, Any], path: str, *, default: Any = None) -> Any:
-    """Safe getter for dotted paths."""
     cur: Any = obj
     for part in path.split("."):
         if isinstance(cur, dict) and part in cur:
@@ -13,41 +12,20 @@ def _g(obj: Dict[str, Any], path: str, *, default: Any = None) -> Any:
             return default
     return cur
 
-def _get_event_name(ev):
-    return _g(ev, "detail.eventName") or ev.get("eventName")
-
-def _get_console_login(ev):
-    return _g(ev, "detail.responseElements.ConsoleLogin") or \
-           _g(ev, "responseElements.ConsoleLogin")
-
-def _get_access_key_id(ev):
-    return _g(ev, "detail.userIdentity.accessKeyId") or \
-           _g(ev, "userIdentity.accessKeyId")
-
-def _get_account_id(ev):
-    return _g(ev, "detail.userIdentity.accountId") or \
-           _g(ev, "userIdentity.accountId")
-
-def _get_user_name(ev):
-    return _g(ev, "detail.userIdentity.userName") or \
-           _g(ev, "userIdentity.userName")
-
-def _get_event_time(ev):
-    return _g(ev, "detail.eventTime") or ev.get("eventTime") or ev.get("time")
-
-def _get_event_source(ev):
-    return _g(ev, "detail.eventSource") or ev.get("eventSource")
-
-def _get_source_ip(ev):
-    return _g(ev, "detail.sourceIPAddress") or ev.get("sourceIPAddress")
-
-def _get_event_id(ev):
-    return _g(ev, "detail.eventID") or ev.get("eventID")
-
+# ---------- Field getters ----------
+def _get_event_name(ev): return _g(ev, "detail.eventName") or ev.get("eventName")
+def _get_console_login(ev): return _g(ev, "detail.responseElements.ConsoleLogin") or _g(ev, "responseElements.ConsoleLogin")
+def _get_access_key_id(ev): return _g(ev, "detail.userIdentity.accessKeyId") or _g(ev, "userIdentity.accessKeyId")
+def _get_account_id(ev): return _g(ev, "detail.userIdentity.accountId") or _g(ev, "userIdentity.accountId")
+def _get_user_name(ev): return _g(ev, "detail.userIdentity.userName") or _g(ev, "userIdentity.userName")
+def _get_user_type(ev): return _g(ev, "detail.userIdentity.type") or _g(ev, "userIdentity.type")
+def _get_event_time(ev): return _g(ev, "detail.eventTime") or ev.get("eventTime") or ev.get("time")
+def _get_event_source(ev): return _g(ev, "detail.eventSource") or ev.get("eventSource")
+def _get_source_ip(ev): return _g(ev, "detail.sourceIPAddress") or ev.get("sourceIPAddress")
+def _get_event_id(ev): return _g(ev, "detail.eventID") or ev.get("eventID")
 
 # ---------- Validation ----------
 def _require_strings(payload: Dict[str, Any], paths: Tuple[str, ...]) -> Tuple[bool, str]:
-    """Validates that each dotted path exists and is a non-empty string."""
     missing = []
     wrong_type = []
     for p in paths:
@@ -65,10 +43,8 @@ def _require_strings(payload: Dict[str, Any], paths: Tuple[str, ...]) -> Tuple[b
         return False, "; ".join(parts)
     return True, ""
 
-
 # ---------- Builder detection ----------
 def _detect_builder(ev: Dict[str, Any]) -> str:
-    """Returns 'access_key' or 'password'."""
     event_name = _get_event_name(ev)
     console_login = _get_console_login(ev)
     access_key_id = _get_access_key_id(ev)
@@ -79,8 +55,7 @@ def _detect_builder(ev: Dict[str, Any]) -> str:
         return "access_key"
     raise ValueError("Unsupported event type for these builders")
 
-
-# ---------- Main mapping ----------
+# ---------- Mapping ----------
 def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
     builder_type = _detect_builder(event)
 
@@ -91,6 +66,7 @@ def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
         "sourceIPAddress": _get_source_ip(event),
         "eventID": _get_event_id(event),
         "userIdentity": {
+            "type": _get_user_type(event),  # <-- added
             "accountId": _get_account_id(event),
             "userName": _get_user_name(event),
             "accessKeyId": _get_access_key_id(event),
@@ -100,12 +76,14 @@ def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
         },
     }
 
+    # Remove fields based on builder type
     if builder_type == "access_key":
         mapped.pop("responseElements", None)
     else:
         if "userIdentity" in mapped and isinstance(mapped["userIdentity"], dict):
             mapped["userIdentity"].pop("accessKeyId", None)
 
+    # Validation
     if builder_type == "access_key":
         ok, err = _require_strings(
             mapped,
@@ -114,6 +92,7 @@ def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
                 "userIdentity.accountId",
                 "userIdentity.accessKeyId",
                 "userIdentity.userName",
+                "userIdentity.type",  # validate type too
             ),
         )
     else:
@@ -123,6 +102,7 @@ def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
                 "eventTime",
                 "userIdentity.accountId",
                 "userIdentity.userName",
+                "userIdentity.type",  # validate type too
                 "eventName",
                 "responseElements.ConsoleLogin",
             ),
@@ -135,7 +115,7 @@ def map_event_to_java_source(event: Dict[str, Any]) -> Dict[str, Any]:
 
     return mapped
 
-
+# ---------- Normalization entry point ----------
 def normalize_aws_syslog(syslog: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
     if isinstance(syslog, str):
         try:

--- a/src/MySnsToPta/lambda_function.py
+++ b/src/MySnsToPta/lambda_function.py
@@ -1,19 +1,19 @@
 import json
 import socket
 import os
-from aws_syslog_mapper import normalize_aws_syslog  # our mapping function
+from typing import Dict, Any
+from aws_syslog_mapper import normalize_aws_syslog
 
 TCP_IP = os.environ['PTAIP']
 TCP_PORT = int(os.environ['PTAPort'])  # PTA Port
-BUFFER_SIZE = 1024
 
-def sendData(sock, msg):
+def sendData(sock: socket.socket, msg: bytes):
     try:
         sock.sendall(msg)
     except:
         print("Failed to send data!")
 
-def lambda_handler(event, context):
+def lambda_handler(event: Dict[str, Any], context: Any):
     print(json.dumps(event))  # For debugging
 
     for record in event["Records"]:
@@ -21,7 +21,6 @@ def lambda_handler(event, context):
             message = parse_and_transform(record)
             print(f"Transformed message: {message}")
 
-            # Open TCP connection
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
                 print(f"Connecting to PTA at {TCP_IP}:{TCP_PORT}")
                 sock.connect((TCP_IP, TCP_PORT))
@@ -37,10 +36,10 @@ def lambda_handler(event, context):
         'body': json.dumps('Lambda to PTA completed successfully!')
     }
 
-def parse_and_transform(record):
+def parse_and_transform(record: Dict[str, Any]) -> str:
     print(f"Record data: {record}")
 
-    if record.get("EventSource") == "aws:sns":
+    if record.get("EventSource") == 'aws:sns':
         print("The event source is aws:sns")
         sns_message = record["Sns"]["Message"]
     else:
@@ -53,5 +52,4 @@ def parse_and_transform(record):
         raise ValueError(f"Invalid JSON in SNS message: {e}")
 
     transformed_event = normalize_aws_syslog(cloudtrail_event)
-
     return json.dumps(transformed_event)

--- a/src/MySnsToPta/lambda_function.py
+++ b/src/MySnsToPta/lambda_function.py
@@ -1,56 +1,57 @@
 import json
 import socket
-import time
-import sys
 import os
+from aws_syslog_mapper import normalize_aws_syslog  # our mapping function
 
 TCP_IP = os.environ['PTAIP']
-TCP_PORT = os.environ['PTAPort'] # PTA Port
+TCP_PORT = int(os.environ['PTAPort'])  # PTA Port
 BUFFER_SIZE = 1024
 
 def sendData(sock, msg):
     try:
         sock.sendall(msg)
     except:
-        print ("Failed to send data!")
-    
-def lambda_handler(event, context):
-    tcp_port = int(TCP_PORT) 
-    sock = 0
-    print(event);
-    for record in event["Records"]: 
-        
-        print ("Connecting to: " + TCP_IP + " Port: " + str(TCP_PORT))
+        print("Failed to send data!")
 
+def lambda_handler(event, context):
+    print(json.dumps(event))  # For debugging
+
+    for record in event["Records"]:
         try:
-            message = parse_json(record) # Validate that the message was sent from SNS
-            print ("Sending message: {0}".format(message))
-            sock = socket.socket( socket.AF_INET, socket.SOCK_STREAM ) # Open Socket with PTA PORT
-            sock.connect((TCP_IP, tcp_port))
-            b_event = str.encode(message)
-            sendData(sock, b_event)
-            print (b_event)
-            
+            message = parse_and_transform(record)
+            print(f"Transformed message: {message}")
+
+            # Open TCP connection
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                print(f"Connecting to PTA at {TCP_IP}:{TCP_PORT}")
+                sock.connect((TCP_IP, TCP_PORT))
+                b_event = message.encode("utf-8")
+                sendData(sock, b_event)
+                print(f"Sent: {b_event}")
+
         except Exception as e:
-            print ('exception, connection failure: '+ str(e))
-            sock = socket.socket( socket.AF_INET, socket.SOCK_STREAM )
-            sock.connect((TCP_IP, tcp_port))
-            sendData(sock, b_event)
-        
+            print(f"Error processing record: {e}")
+
     return {
         'statusCode': 200,
-        'body': json.dumps('Lambda to PTA completed successfuly!')
+        'body': json.dumps('Lambda to PTA completed successfully!')
     }
 
-def parse_json(record):
-    #data = json.load(jsonData)
-    #print (data)
-    #for record in data["Records"]:
-    print("Record data: {0}".format(record))
-    if (record["EventSource"] == 'aws:sns'):
-        print ("The event source is aws:sns")
-        return record["Sns"]["Message"]
-        
+def parse_and_transform(record):
+    print(f"Record data: {record}")
+
+    if record.get("EventSource") == "aws:sns":
+        print("The event source is aws:sns")
+        sns_message = record["Sns"]["Message"]
     else:
-        print ("The event source is {0}".format(record["EventSource"]))
-        return record
+        print(f"The event source is {record.get('EventSource')}")
+        sns_message = json.dumps(record)
+
+    try:
+        cloudtrail_event = json.loads(sns_message)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in SNS message: {e}")
+
+    transformed_event = normalize_aws_syslog(cloudtrail_event)
+
+    return json.dumps(transformed_event)

--- a/src/PtaCloudTrailToSns/index.js
+++ b/src/PtaCloudTrailToSns/index.js
@@ -1,9 +1,9 @@
-var aws  = require('aws-sdk');
+var aws = require('aws-sdk');
 var zlib = require('zlib');
 var async = require('async');
 
-var DEFAULT_SNS_REGION  = process.env.SNSREGION;
-var SNS_TOPIC_ARN       = process.env.SNSTOPICARN;
+var DEFAULT_SNS_REGION = process.env.SNSREGION;
+var SNS_TOPIC_ARN = process.env.SNSTOPICARN;
 
 var s3 = new aws.S3();
 var sns = new aws.SNS({
@@ -15,17 +15,16 @@ exports.handler = function(event, context, callback) {
     console.log(JSON.stringify(event));
     var srcBucket = event.Records[0].s3.bucket.name;
     var srcKey = event.Records[0].s3.object.key;
-   
+
     async.waterfall([
-        function fetchLogFromS3(next){
+        function fetchLogFromS3(next) {
             console.log('Fetching compressed log from S3...');
             s3.getObject({
-               Bucket: srcBucket,
-               Key: srcKey
-            },
-            next);
+                Bucket: srcBucket,
+                Key: srcKey
+            }, next);
         },
-        function uncompressLog(response, next){
+        function uncompressLog(response, next) {
             console.log("Uncompressing log...");
             zlib.gunzip(response.Body, next);
         },
@@ -33,6 +32,7 @@ exports.handler = function(event, context, callback) {
             console.log('Filtering log...');
             var json = jsonBuffer.toString();
             console.log('CloudTrail JSON from S3:', json);
+
             var records;
             try {
                 records = JSON.parse(json);
@@ -40,32 +40,40 @@ exports.handler = function(event, context, callback) {
                 next('Unable to parse CloudTrail JSON: ' + err);
                 return;
             }
-            var matchingRecords = records
-                .Records
-                .filter(function(record) {
-                    return record.userIdentity.accessKeyId;
-                });
-                
+
+            // Filter for both accessKey logons and password ConsoleLogin logons
+            var matchingRecords = records.Records.filter(function(record) {
+                // Access key case
+                var hasAccessKey = record.userIdentity && record.userIdentity.accessKeyId;
+
+                // Password (ConsoleLogin) case
+                var isConsoleLogin = record.eventName === "ConsoleLogin" &&
+                                     record.responseElements &&
+                                     typeof record.responseElements.ConsoleLogin === "string";
+
+                return hasAccessKey || isConsoleLogin;
+            });
+
             console.log('Publishing ' + matchingRecords.length + ' notification(s) in parallel...');
+
             async.each(
                 matchingRecords,
                 function(record, publishComplete) {
                     console.log('Publishing notification: ', record);
                     sns.publish({
-                        Message:
-                            JSON.stringify(record),
+                        Message: JSON.stringify(record),
                         TopicArn: SNS_TOPIC_ARN
                     }, publishComplete);
                 },
                 next
             );
         }
-    ], function (err) {
+    ], function(err) {
         if (err) {
             console.error('Failed to publish notifications: ', err);
         } else {
             console.log('Successfully published all notifications.');
         }
-        callback(null,"message");
+        callback(null, "message");
     });
 };


### PR DESCRIPTION
### Desired Outcome

The goal of this PR is to ensure AWS CloudTrail logon events — both Access Key and Password (ConsoleLogin) types — are correctly collected from S3, filtered, and transformed into the exact JSON format expected by PTA’s Java audit builders before being sent over TCP.

Previously, only Access Key events were sent in the old format. With recent changes to AWS syslog structure, we needed to support the newer format and ensure PTA still receives compatible payloads.

### Implemented Changes

Lambda 1 (Node.js)

- Updated the filtering logic to include both:
- Access Key events (userIdentity.accessKeyId exists)
- Password-based ConsoleLogin events (eventName == "ConsoleLogin" with responseElements.ConsoleLogin present)
- No other behavior changes — logs are still fetched from S3, uncompressed, filtered, and sent to SNS.

Lambda 2 (Python)

- Integrated a new mapping function (normalize_aws_syslog) to transform incoming CloudTrail events from SNS into the Java-builder-compatible "source" JSON payload format.
- Sends only the mapped source data over TCP to PTA, ensuring compatibility regardless of whether the event is Access Key or Password-based.
- Verified the new Lambda 1 filter passes Access Key and Password (both success and failure) events and rejects unrelated events.
- Confirmed the Python mapper outputs exactly the JSON structure expected by PTA’s Java code for all supported event types.

Reviewer guidance:

You can manually test by uploading a sample CloudTrail gzip file to the configured S3 bucket containing both Access Key and ConsoleLogin events.

Verify that SNS receives the correct events, and that PTA logs show them with the expected "source" JSON format.